### PR TITLE
fix: command is not available

### DIFF
--- a/app/Commands/PackageInitCommand.php
+++ b/app/Commands/PackageInitCommand.php
@@ -19,7 +19,7 @@ use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
 use function Laravel\Prompts\table;
 
-class PackageInit extends Command implements HasPackageConfiguration, PromptsForMissingInput
+class PackageInitCommand extends Command implements HasPackageConfiguration, PromptsForMissingInput
 {
     use ConcernsPromptsForMissingInput;
     use InteractsWithPackageConfiguration {

--- a/config/commands.php
+++ b/config/commands.php
@@ -40,7 +40,7 @@ return [
     */
 
     'add' => [
-        //
+        \App\Commands\PackageInitCommand::class,
     ],
 
     /*


### PR DESCRIPTION
The command for some reason locally is loading the commands directly form the `Commands` folder, but when it comes to building in the release, this does not work, so the command is not present.